### PR TITLE
Add damage report management with uploads and filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log*
 # OS & editor files
 .DS_Store
 .vscode/
+backend/uploads/

--- a/backend/models/DamageReport.js
+++ b/backend/models/DamageReport.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose');
+
+const damageReportSchema = new mongoose.Schema(
+  {
+    unitId: { type: String, required: true, trim: true },
+    licensePlate: { type: String, trim: true },
+    incidentDateTime: { type: Date, required: true },
+    location: { type: String, required: true, trim: true },
+    crew: { type: String, trim: true },
+    shift: { type: String, trim: true },
+    damageArea: { type: String, required: true },
+    severity: { type: String, required: true },
+    damageCause: { type: String, required: true },
+    description: { type: String, required: true },
+    weather: { type: String, trim: true },
+    thirdParties: { type: String, trim: true },
+    policeReportNumber: { type: String, trim: true },
+    witnesses: { type: String, trim: true },
+    immediateAction: { type: String, trim: true },
+    damageStatus: { type: String, default: 'Reported' },
+    repairCost: { type: Number, min: 0 },
+    assignedVendor: { type: String, trim: true },
+    repairDate: { type: Date },
+    insuranceClaimFiled: { type: Boolean, default: false },
+    insuranceClaimNumber: { type: String, trim: true },
+    reportedBy: { type: String, required: true, trim: true },
+    supervisorStatus: { type: String, default: 'Pending review' },
+    priority: { type: String, default: 'Moderate' },
+    managerNotes: { type: String, trim: true },
+    notifyTeam: { type: Boolean, default: true },
+    attachments: [{ type: String, trim: true }],
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('DamageReport', damageReportSchema);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,8 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "mongodb": "^6.17.0",
-        "mongoose": "^8.16.0"
+        "mongoose": "^8.16.0",
+        "multer": "^1.4.5-lts.1"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -53,6 +54,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -80,6 +87,23 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -120,6 +144,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -158,6 +197,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -501,6 +546,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -565,6 +616,27 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mongodb": {
@@ -672,6 +744,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -741,6 +875,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -801,6 +941,27 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -983,6 +1144,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1018,6 +1202,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1026,6 +1216,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -1063,6 +1259,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "mongodb": "^6.17.0",
-    "mongoose": "^8.16.0"
+    "mongoose": "^8.16.0",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/backend/routes/damageReportRoutes.js
+++ b/backend/routes/damageReportRoutes.js
@@ -1,0 +1,553 @@
+﻿const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+const DamageReport = require('../models/DamageReport');
+const AmbulanceUnit = require('../models/AmbulanceUnit');
+
+const router = express.Router();
+
+const uploadsRoot = path.join(__dirname, '..', 'uploads', 'damage_reports');
+fs.mkdirSync(uploadsRoot, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, callback) => {
+    callback(null, uploadsRoot);
+  },
+  filename: (_req, file, callback) => {
+    const safeName = file.originalname ? file.originalname.replace(/[^a-zA-Z0-9_.-]/g, '_') : 'attachment';
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const extension = path.extname(safeName);
+    callback(null, `${uniqueSuffix}${extension}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: {
+    files: 10,
+    fileSize: 10 * 1024 * 1024,
+  },
+});
+
+const HIGH_SEVERITY = new Set(['Major', 'Critical']);
+
+const toArray = (value) => {
+  if (!value && value !== 0) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return [value];
+};
+
+const parseBoolean = (value, defaultValue = false) => {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const parseNumber = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? null : numeric;
+};
+
+const parseDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const normaliseString = (value) => (typeof value === 'string' ? value.trim() : value);
+
+const getAttachmentPaths = (files) =>
+  (files || []).map((file) => path.posix.join('uploads/damage_reports', file.filename));
+
+const buildReportPayload = (body, files, options = {}) => {
+  const { useDefaults = true } = options;
+  const payload = {};
+
+  const withDefault = (value, fallback) => {
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+    return useDefaults ? fallback : undefined;
+  };
+
+  const assignIfPresent = (key, rawValue, { allowEmpty = false } = {}) => {
+    const value = normaliseString(rawValue);
+    if (value || allowEmpty) {
+      payload[key] = allowEmpty ? value ?? '' : value;
+    }
+  };
+
+  assignIfPresent('unitId', body.unitId);
+  assignIfPresent('licensePlate', body.licensePlate);
+
+  const incidentDate = parseDate(body.incidentDateTime);
+  if (incidentDate) {
+    payload.incidentDateTime = incidentDate;
+  } else if (useDefaults && body.incidentDateTime) {
+    payload.incidentDateTime = body.incidentDateTime;
+  }
+
+  assignIfPresent('location', body.location);
+  assignIfPresent('crew', body.crew);
+  assignIfPresent('shift', body.shift);
+  assignIfPresent('damageArea', body.damageArea);
+  assignIfPresent('severity', body.severity);
+  assignIfPresent('damageCause', body.damageCause);
+  assignIfPresent('description', body.description);
+  assignIfPresent('weather', body.weather);
+  assignIfPresent('thirdParties', body.thirdParties);
+  assignIfPresent('policeReportNumber', body.policeReportNumber);
+  assignIfPresent('witnesses', body.witnesses);
+  assignIfPresent('immediateAction', body.immediateAction);
+
+  const damageStatus = withDefault(normaliseString(body.damageStatus), 'Reported');
+  if (damageStatus !== undefined) {
+    payload.damageStatus = damageStatus;
+  }
+
+  const supervisorStatus = withDefault(normaliseString(body.supervisorStatus), 'Pending review');
+  if (supervisorStatus !== undefined) {
+    payload.supervisorStatus = supervisorStatus;
+  }
+
+  const priority = withDefault(normaliseString(body.priority), 'Moderate');
+  if (priority !== undefined) {
+    payload.priority = priority;
+  }
+
+  const repairCost = parseNumber(body.repairCost);
+  if (repairCost !== null) {
+    payload.repairCost = repairCost;
+  }
+
+  const repairDate = parseDate(body.repairDate);
+  if (repairDate) {
+    payload.repairDate = repairDate;
+  }
+
+  assignIfPresent('assignedVendor', body.assignedVendor);
+  assignIfPresent('managerNotes', body.managerNotes, { allowEmpty: true });
+
+  const insuranceClaimFiled = withDefault(parseBoolean(body.insuranceClaimFiled, false), false);
+  if (insuranceClaimFiled !== undefined) {
+    payload.insuranceClaimFiled = insuranceClaimFiled;
+  }
+
+  if (insuranceClaimFiled) {
+    assignIfPresent('insuranceClaimNumber', body.insuranceClaimNumber);
+  }
+
+  assignIfPresent('reportedBy', body.reportedBy);
+
+  if (Object.prototype.hasOwnProperty.call(body, 'notifyTeam') || useDefaults) {
+    payload.notifyTeam = parseBoolean(body.notifyTeam, true);
+  }
+
+  const attachmentsFromFiles = getAttachmentPaths(files);
+  if (attachmentsFromFiles.length) {
+    payload.attachments = attachmentsFromFiles;
+  } else if (body.attachments) {
+    try {
+      const parsedAttachments = JSON.parse(body.attachments);
+      if (Array.isArray(parsedAttachments)) {
+        payload.attachments = parsedAttachments;
+      } else {
+        payload.attachments = toArray(body.attachments);
+      }
+    } catch (_) {
+      payload.attachments = toArray(body.attachments);
+    }
+  }
+
+  if (!payload.repairDate && !Object.prototype.hasOwnProperty.call(body, 'repairDate')) {
+    delete payload.repairDate;
+  }
+
+  Object.keys(payload).forEach((key) => {
+    if (payload[key] === undefined || payload[key] === '') {
+      delete payload[key];
+    }
+  });
+
+  return payload;
+};
+
+const shouldMarkOutOfService = (report, forceFlag) => {
+  if (forceFlag) {
+    return true;
+  }
+
+  if (!report) {
+    return false;
+  }
+
+  return (
+    HIGH_SEVERITY.has(report.severity) ||
+    report.damageStatus === 'In repair' ||
+    report.damageStatus === 'Under inspection' ||
+    report.immediateAction === 'Removed from service'
+  );
+};
+
+const pruneEmptyOperators = (operators) =>
+  Object.entries(operators).reduce((acc, [operator, value]) => {
+    if (value === undefined || value === null) {
+      return acc;
+    }
+
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      const entries = Object.entries(value).filter(([_, inner]) => {
+        if (inner === undefined || inner === null) {
+          return false;
+        }
+
+        if (typeof inner === 'string') {
+          return inner.trim().length > 0;
+        }
+
+        if (Array.isArray(inner)) {
+          return inner.length > 0;
+        }
+
+        if (typeof inner === 'object') {
+          return Object.keys(inner).length > 0;
+        }
+
+        return true;
+      });
+
+      if (entries.length > 0) {
+        acc[operator] = Object.fromEntries(entries);
+      }
+
+      return acc;
+    }
+
+    if (typeof value === 'string' && value.trim().length === 0) {
+      return acc;
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+      return acc;
+    }
+
+    acc[operator] = value;
+    return acc;
+  }, {});
+
+const buildUnitUpdate = (report, options = {}) => {
+  if (!report || !report._id) {
+    return {};
+  }
+
+  const update = {
+    $addToSet: { damageReports: report._id.toString() },
+  };
+
+  if (options.summary) {
+    update.$push = { issues: options.summary };
+  }
+
+  if (options.restoreOperation) {
+    update.$set = { ...update.$set, isOperational: true };
+  } else if (shouldMarkOutOfService(report, options.forceOutOfService)) {
+    update.$set = { ...update.$set, isOperational: false };
+  }
+
+  return pruneEmptyOperators(update);
+};
+
+const buildListFilter = (query) => {
+  const clauses = [];
+
+  const severity = toArray(query.severity);
+  if (severity.length) {
+    clauses.push({ severity: { $in: severity } });
+  }
+
+  const status = toArray(query.status || query.damageStatus);
+  if (status.length) {
+    clauses.push({ damageStatus: { $in: status } });
+  }
+
+  const priority = toArray(query.priority);
+  if (priority.length) {
+    clauses.push({ priority: { $in: priority } });
+  }
+
+  const unitId = normaliseString(query.unitId);
+  if (unitId) {
+    clauses.push({ unitId });
+  }
+
+  const reportedBy = normaliseString(query.reportedBy);
+  if (reportedBy) {
+    clauses.push({ reportedBy });
+  }
+
+  const dateRange = {};
+  const fromDate = parseDate(query.dateFrom);
+  if (fromDate) {
+    dateRange.$gte = fromDate;
+  }
+  const toDate = parseDate(query.dateTo);
+  if (toDate) {
+    dateRange.$lte = toDate;
+  }
+  if (Object.keys(dateRange).length) {
+    clauses.push({ incidentDateTime: dateRange });
+  }
+
+  const searchTerm = normaliseString(query.search);
+  if (searchTerm) {
+    const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(escaped, 'i');
+    clauses.push({
+      $or: [
+        { unitId: regex },
+        { licensePlate: regex },
+        { damageArea: regex },
+        { damageStatus: regex },
+        { priority: regex },
+        { severity: regex },
+        { reportedBy: regex },
+        { immediateAction: regex },
+      ],
+    });
+  }
+
+  return clauses.length ? { $and: clauses } : {};
+};
+
+// @route   POST /api/damage-reports
+// @desc    Create a new damage report
+router.post('/', upload.array('attachments'), async (req, res) => {
+  try {
+    const payload = buildReportPayload(req.body, req.files);
+
+    const report = await DamageReport.create(payload);
+
+    if (report.unitId) {
+      const summary = `New damage report recorded (${report.severity}) for unit ${report.unitId}`;
+      const unitUpdate = buildUnitUpdate(report, { summary });
+
+      if (Object.keys(unitUpdate).length > 0) {
+        try {
+          await AmbulanceUnit.findOneAndUpdate({ unitNumber: report.unitId }, unitUpdate);
+        } catch (unitError) {
+          console.error(`Failed to sync damage report ${report._id} to unit ${report.unitId}:`, unitError.message);
+        }
+      }
+    }
+
+    console.info(`Damage report ${report._id} recorded for unit ${report.unitId || 'unknown'}.`);
+
+    res.status(201).json(report);
+  } catch (error) {
+    res.status(400).json({ message: 'Error creating damage report', error: error.message });
+  }
+});
+
+// @route   GET /api/damage-reports
+// @desc    List damage reports (most recent first)
+router.get('/', async (req, res) => {
+  try {
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 10, 1), 50);
+    const skip = (page - 1) * limit;
+
+    const filter = buildListFilter(req.query);
+
+    const [reports, total] = await Promise.all([
+      DamageReport.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit),
+      DamageReport.countDocuments(filter),
+    ]);
+
+    res.json({
+      reports,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit) || 1,
+      totalReports: total,
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Error fetching damage reports', error: error.message });
+  }
+});
+
+// @route   GET /api/damage-reports/:id
+// @desc    Fetch a specific damage report
+router.get('/:id', async (req, res) => {
+  try {
+    const report = await DamageReport.findById(req.params.id);
+
+    if (!report) {
+      return res.status(404).json({ message: 'Damage report not found' });
+    }
+
+    res.json(report);
+  } catch (error) {
+    res.status(400).json({ message: 'Error fetching damage report', error: error.message });
+  }
+});
+
+// @route   PATCH /api/damage-reports/:id
+// @desc    Update a damage report (status, follow-up details, etc.)
+router.patch('/:id', upload.array('attachments'), async (req, res) => {
+  try {
+    const report = await DamageReport.findById(req.params.id);
+
+    if (!report) {
+      return res.status(404).json({ message: 'Damage report not found' });
+    }
+
+    const previousState = {
+      damageStatus: report.damageStatus,
+      supervisorStatus: report.supervisorStatus,
+      priority: report.priority,
+    };
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'damageStatus')) {
+      const value = normaliseString(req.body.damageStatus);
+      if (value) {
+        report.damageStatus = value;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'supervisorStatus')) {
+      const value = normaliseString(req.body.supervisorStatus);
+      if (value) {
+        report.supervisorStatus = value;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'priority')) {
+      const value = normaliseString(req.body.priority);
+      if (value) {
+        report.priority = value;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'managerNotes')) {
+      const value = normaliseString(req.body.managerNotes);
+      report.managerNotes = value || undefined;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'notifyTeam')) {
+      report.notifyTeam = parseBoolean(req.body.notifyTeam, report.notifyTeam);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'repairDate')) {
+      const parsed = parseDate(req.body.repairDate);
+      report.repairDate = parsed || null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'repairCost')) {
+      const parsed = parseNumber(req.body.repairCost);
+      if (parsed === null) {
+        report.repairCost = undefined;
+      } else {
+        report.repairCost = parsed;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'assignedVendor')) {
+      const value = normaliseString(req.body.assignedVendor);
+      report.assignedVendor = value || undefined;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body, 'immediateAction')) {
+      const value = normaliseString(req.body.immediateAction);
+      report.immediateAction = value || undefined;
+    }
+
+    const newAttachments = getAttachmentPaths(req.files);
+    if (newAttachments.length) {
+      report.attachments = [...(report.attachments || []), ...newAttachments];
+    }
+
+    await report.save();
+
+    if (report.unitId) {
+      const summaryParts = [];
+
+      if (previousState.damageStatus !== report.damageStatus) {
+        summaryParts.push(`status -> ${report.damageStatus}`);
+      }
+      if (previousState.supervisorStatus !== report.supervisorStatus) {
+        summaryParts.push(`supervisor review -> ${report.supervisorStatus}`);
+      }
+      if (previousState.priority !== report.priority) {
+        summaryParts.push(`priority -> ${report.priority}`);
+      }
+
+      const summary = summaryParts.length > 0
+        ? `Damage report ${report._id} updated (${summaryParts.join(', ')})`
+        : undefined;
+
+      const unitUpdateOptions = { summary };
+
+      if (previousState.damageStatus !== report.damageStatus) {
+        if (report.damageStatus === 'Resolved') {
+          unitUpdateOptions.restoreOperation = true;
+        } else {
+          unitUpdateOptions.forceOutOfService = true;
+        }
+      }
+
+      const unitUpdate = buildUnitUpdate(report, unitUpdateOptions);
+
+      if (Object.keys(unitUpdate).length > 0) {
+        try {
+          await AmbulanceUnit.findOneAndUpdate({ unitNumber: report.unitId }, unitUpdate);
+        } catch (unitError) {
+          console.error(`Failed to update unit ${report.unitId} for damage report ${report._id}:`, unitError.message);
+        }
+      }
+    }
+
+    res.json(report);
+  } catch (error) {
+    res.status(400).json({ message: 'Error updating damage report', error: error.message });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,10 @@
-// server.js
+﻿// server.js
 
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const path = require('path');
+const fs = require('fs');
 require('dotenv').config();
 
 const app = express();
@@ -12,7 +14,14 @@ app.use(cors());
 app.use(express.json());
 
 const ambulanceRoutes = require('./routes/ambulanceRoutes');
+const damageReportRoutes = require('./routes/damageReportRoutes');
+
+const uploadsDir = path.join(__dirname, 'uploads');
+fs.mkdirSync(uploadsDir, { recursive: true });
+app.use('/uploads', express.static(uploadsDir));
+
 app.use('/api/units', ambulanceRoutes);
+app.use('/api/damage-reports', damageReportRoutes);
 
 // Test route
 app.get('/api/health', (req, res) => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import DashboardPage from "./pages/DashboardPage";
 import ReportDamagePage from "./pages/ReportDamagePage";
+import DamageReportsPage from "./pages/DamageReportsPage";
+import DamageReportDetailPage from "./pages/DamageReportDetailPage";
 import MaintenanceTrackerPage from "./pages/MaintenanceTrackerPage";
 import FleetOverviewPage from "./pages/FleetOverviewPage";
 import InspectionLogPage from "./pages/InspectionLogPage";
@@ -11,10 +13,12 @@ import AdminPanelPage from "./pages/AdminPanelPage";
 function App() {
   return (
     <Router>
-      <Navbar/>
+      <Navbar />
       <Routes>
         <Route path="/" element={<DashboardPage />} />
         <Route path="/report-damage" element={<ReportDamagePage />} />
+        <Route path="/damage-reports" element={<DamageReportsPage />} />
+        <Route path="/damage-reports/:reportId" element={<DamageReportDetailPage />} />
         <Route path="/maintenance-tracker" element={<MaintenanceTrackerPage />} />
         <Route path="/fleet-overview" element={<FleetOverviewPage />} />
         <Route path="/inspection-log" element={<InspectionLogPage />} />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -10,6 +10,7 @@ const Navbar = () => {
       <div className="space-x-4 flex flex-wrap justify-center">
         <Link to="/" className="hover:text-gray-300 transition">Dashboard</Link>
         <Link to="/report-damage" className="hover:text-gray-300 transition">Report Damage</Link>
+        <Link to="/damage-reports" className="hover:text-gray-300 transition">Damage Reports</Link>
         <Link to="/maintenance-tracker" className="hover:text-gray-300 transition">Maintenance Tracker</Link>
         <Link to="/fleet-overview" className="hover:text-gray-300 transition">Fleet Overview</Link>
         <Link to="/inspection-log" className="hover:text-gray-300 transition">Inspection Log</Link>

--- a/frontend/src/constants/damageReportOptions.js
+++ b/frontend/src/constants/damageReportOptions.js
@@ -1,0 +1,40 @@
+export const damageAreas = [
+  'Front bumper',
+  'Rear bumper',
+  'Driver side door',
+  'Passenger side door',
+  'Roof',
+  'Undercarriage',
+  'Engine compartment',
+  'Electrical system',
+  'Oxygen delivery system',
+  'Interior compartment',
+  'Medical equipment',
+  'Other',
+];
+
+export const severityLevels = ['Minor', 'Moderate', 'Major', 'Critical'];
+
+export const damageCauses = [
+  'Collision with vehicle',
+  'Collision with object',
+  'Mechanical failure',
+  'Wear and tear',
+  'Vandalism',
+  'Weather',
+  'Other',
+];
+
+export const immediateActions = [
+  'Continued operation',
+  'Towed to facility',
+  'Temporary fix applied',
+  'Removed from service',
+  'Awaiting assessment',
+];
+
+export const statusOptions = ['Reported', 'Under inspection', 'In repair', 'Resolved'];
+
+export const supervisorStatuses = ['Pending review', 'Approved', 'Needs follow-up'];
+
+export const priorityLevels = ['Low', 'Moderate', 'High', 'Critical'];

--- a/frontend/src/pages/DamageReportDetailPage.js
+++ b/frontend/src/pages/DamageReportDetailPage.js
@@ -1,0 +1,425 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import axios from "axios";
+import {
+  immediateActions,
+  priorityLevels,
+  statusOptions,
+  supervisorStatuses,
+} from "../constants/damageReportOptions";
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:5000";
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return "N/A";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+};
+
+const mapReportToForm = (report) => ({
+  damageStatus: report.damageStatus || statusOptions[0],
+  supervisorStatus: report.supervisorStatus || supervisorStatuses[0],
+  priority: report.priority || priorityLevels[1],
+  managerNotes: report.managerNotes || "",
+  notifyTeam: Boolean(report.notifyTeam),
+  assignedVendor: report.assignedVendor || "",
+  repairDate: report.repairDate ? report.repairDate.slice(0, 10) : "",
+  repairCost:
+    report.repairCost !== undefined && report.repairCost !== null
+      ? String(report.repairCost)
+      : "",
+  immediateAction: report.immediateAction || "",
+});
+
+const DamageReportDetailPage = () => {
+  const { reportId } = useParams();
+  const [report, setReport] = useState(null);
+  const [formData, setFormData] = useState(mapReportToForm({}));
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [submitStatus, setSubmitStatus] = useState({ type: "", message: "" });
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    const fetchReport = async () => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const res = await axios.get(`${API_BASE_URL}/api/damage-reports/${reportId}`);
+        setReport(res.data);
+        setFormData(mapReportToForm(res.data));
+      } catch (err) {
+        console.error(`Failed to load damage report ${reportId}:`, err);
+        const message = err.response?.data?.message || "Unable to load this damage report right now.";
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchReport();
+  }, [reportId]);
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSaving(true);
+    setSubmitStatus({ type: "", message: "" });
+
+    const payload = {
+      damageStatus: formData.damageStatus,
+      supervisorStatus: formData.supervisorStatus,
+      priority: formData.priority,
+      managerNotes: formData.managerNotes,
+      notifyTeam: formData.notifyTeam,
+      assignedVendor: formData.assignedVendor,
+      repairDate: formData.repairDate || null,
+      repairCost: formData.repairCost === "" ? "" : Number(formData.repairCost),
+      immediateAction: formData.immediateAction,
+    };
+
+    try {
+      const res = await axios.patch(`${API_BASE_URL}/api/damage-reports/${reportId}`, payload);
+      setReport(res.data);
+      setFormData(mapReportToForm(res.data));
+      setSubmitStatus({ type: "success", message: "Updates saved successfully." });
+    } catch (err) {
+      console.error(`Failed to update damage report ${reportId}:`, err);
+      const message = err.response?.data?.message || "Unable to save your changes. Please try again.";
+      setSubmitStatus({ type: "error", message });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-slate-50 min-h-screen py-8">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="text-gray-600">Loading damage report...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-slate-50 min-h-screen py-8">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-4 border-l-4 border-red-400 bg-red-50 px-4 py-3 text-red-700 rounded-md">
+            {error}
+          </div>
+          <Link
+            to="/damage-reports"
+            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700"
+          >
+            Back to damage reports
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return null;
+  }
+
+  const messageClassName =
+    submitStatus.type === "success"
+      ? "border-green-400 bg-green-50 text-green-700"
+      : submitStatus.type === "error"
+      ? "border-red-400 bg-red-50 text-red-700"
+      : "border-blue-400 bg-blue-50 text-blue-700";
+
+  return (
+    <div className="bg-slate-50 min-h-screen py-8">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+          <div>
+            <h1 className="text-3xl font-semibold text-gray-800">Damage Report Detail</h1>
+            <p className="mt-2 text-gray-600">
+              Track remediation and close the loop on damage report {report._id}.
+            </p>
+          </div>
+          <Link
+            to="/damage-reports"
+            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50"
+          >
+            Back to list
+          </Link>
+        </div>
+
+        <section className="bg-white shadow rounded-lg p-6 mb-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Report Overview</h2>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4 text-sm text-gray-700">
+            <div>
+              <dt className="font-medium text-gray-600">Unit</dt>
+              <dd>{report.unitId || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">License Plate</dt>
+              <dd>{report.licensePlate || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Severity</dt>
+              <dd>{report.severity || 'Unknown'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Damage Area</dt>
+              <dd>{report.damageArea || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Cause</dt>
+              <dd>{report.damageCause || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Incident Time</dt>
+              <dd>{formatDateTime(report.incidentDateTime)}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Reported By</dt>
+              <dd>{report.reportedBy || 'N/A'}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-gray-600">Crew / Shift</dt>
+              <dd>{report.crew ? `${report.crew} (${report.shift || 'Shift not noted'})` : report.shift || 'N/A'}</dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="font-medium text-gray-600">Description</dt>
+              <dd className="mt-1 whitespace-pre-wrap text-gray-700">{report.description || 'N/A'}</dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="font-medium text-gray-600">Incident Circumstances</dt>
+              <dd className="mt-1 text-gray-700">
+                <span className="block">Weather / Road: {report.weather || 'N/A'}</span>
+                <span className="block">Third Parties: {report.thirdParties || 'N/A'}</span>
+                <span className="block">Witnesses: {report.witnesses || 'N/A'}</span>
+                <span className="block">Police Report #: {report.policeReportNumber || 'N/A'}</span>
+              </dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="font-medium text-gray-600">Attachments</dt>
+              <dd className="mt-1 text-gray-700">
+                {report.attachments && report.attachments.length > 0 ? (
+                  <ul className="list-disc list-inside space-y-1">
+                    {report.attachments.map((fileName) => {
+                      const href = fileName.startsWith('http')
+                        ? fileName
+                        : `${API_BASE_URL}/${fileName}`.replace(/([^:]\/)\/+/g, '$1');
+                      const label = fileName.split('/').pop();
+
+                      return (
+                        <li key={fileName}>
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-800"
+                          >
+                            {label || fileName}
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <span>No attachments uploaded.</span>
+                )}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="bg-white shadow rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">Follow-up &amp; Resolution</h2>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="damageStatus" className="block text-sm font-medium text-gray-700">
+                  Damage Status
+                </label>
+                <select
+                  id="damageStatus"
+                  name="damageStatus"
+                  value={formData.damageStatus}
+                  onChange={handleChange}
+                  className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {statusOptions.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="priority" className="block text-sm font-medium text-gray-700">
+                  Priority Level
+                </label>
+                <select
+                  id="priority"
+                  name="priority"
+                  value={formData.priority}
+                  onChange={handleChange}
+                  className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {priorityLevels.map((priority) => (
+                    <option key={priority} value={priority}>
+                      {priority}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="supervisorStatus" className="block text-sm font-medium text-gray-700">
+                  Supervisor Review Status
+                </label>
+                <select
+                  id="supervisorStatus"
+                  name="supervisorStatus"
+                  value={formData.supervisorStatus}
+                  onChange={handleChange}
+                  className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  {supervisorStatuses.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="immediateAction" className="block text-sm font-medium text-gray-700">
+                  Immediate Action Taken
+                </label>
+                <select
+                  id="immediateAction"
+                  name="immediateAction"
+                  value={formData.immediateAction}
+                  onChange={handleChange}
+                  className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="">Select an action (optional)</option>
+                  {immediateActions.map((action) => (
+                    <option key={action} value={action}>
+                      {action}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="assignedVendor" className="block text-sm font-medium text-gray-700">
+                  Assigned Mechanic / Vendor
+                </label>
+                <input
+                  id="assignedVendor"
+                  name="assignedVendor"
+                  value={formData.assignedVendor}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="Vendor or shop handling repairs"
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label htmlFor="repairDate" className="block text-sm font-medium text-gray-700">
+                  Repair Completion Date
+                </label>
+                <input
+                  id="repairDate"
+                  name="repairDate"
+                  value={formData.repairDate}
+                  onChange={handleChange}
+                  type="date"
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+              <div>
+                <label htmlFor="repairCost" className="block text-sm font-medium text-gray-700">
+                  Repair Cost (USD)
+                </label>
+                <input
+                  id="repairCost"
+                  name="repairCost"
+                  value={formData.repairCost}
+                  onChange={handleChange}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="Enter cost or leave blank"
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="managerNotes" className="block text-sm font-medium text-gray-700">
+                Fleet Manager Notes
+              </label>
+              <textarea
+                id="managerNotes"
+                name="managerNotes"
+                value={formData.managerNotes}
+                onChange={handleChange}
+                rows={4}
+                placeholder="Document approvals, vendor updates, or next steps."
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <label className="inline-flex items-center text-sm text-gray-700">
+              <input
+                type="checkbox"
+                name="notifyTeam"
+                checked={formData.notifyTeam}
+                onChange={handleChange}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="ml-2">Send notifications to fleet management team</span>
+            </label>
+
+            {submitStatus.message && (
+              <div className={`${messageClassName} border-l-4 rounded-md p-4`}>{submitStatus.message}</div>
+            )}
+
+            <div className="flex justify-end gap-3">
+              <Link
+                to="/damage-reports"
+                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50"
+              >
+                Cancel
+              </Link>
+              <button
+                type="submit"
+                disabled={isSaving}
+                className="inline-flex items-center rounded-md bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSaving ? "Saving..." : "Save Changes"}
+              </button>
+            </div>
+          </form>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default DamageReportDetailPage;

--- a/frontend/src/pages/DamageReportsPage.js
+++ b/frontend/src/pages/DamageReportsPage.js
@@ -1,0 +1,359 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import axios from "axios";
+import {
+  priorityLevels,
+  severityLevels,
+  statusOptions,
+} from "../constants/damageReportOptions";
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:5000";
+const PAGE_SIZE = 10;
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return "â€”";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+};
+
+const DamageReportsPage = () => {
+  const [reports, setReports] = useState([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalReports, setTotalReports] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [severityFilter, setSeverityFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  useEffect(() => {
+    setPage((prev) => (prev === 1 ? prev : 1));
+  }, [searchTerm, severityFilter, statusFilter, priorityFilter, dateFrom, dateTo]);
+
+  useEffect(() => {
+    const fetchReports = async () => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const params = {
+          page,
+          limit: PAGE_SIZE,
+        };
+
+        if (searchTerm.trim()) {
+          params.search = searchTerm.trim();
+        }
+        if (severityFilter) {
+          params.severity = severityFilter;
+        }
+        if (statusFilter) {
+          params.status = statusFilter;
+        }
+        if (priorityFilter) {
+          params.priority = priorityFilter;
+        }
+        if (dateFrom) {
+          params.dateFrom = dateFrom;
+        }
+        if (dateTo) {
+          params.dateTo = dateTo;
+        }
+
+        const res = await axios.get(`${API_BASE_URL}/api/damage-reports`, { params });
+
+        setReports(res.data.reports || []);
+        setTotalPages(res.data.totalPages || 1);
+        setTotalReports(res.data.totalReports || 0);
+      } catch (err) {
+        console.error("Failed to load damage reports:", err);
+        const message = err.response?.data?.message || "Unable to load damage reports right now.";
+        setError(message);
+        setReports([]);
+        setTotalReports(0);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchReports();
+  }, [page, searchTerm, severityFilter, statusFilter, priorityFilter, dateFrom, dateTo]);
+
+  const handlePrevPage = () => {
+    setPage((prev) => Math.max(prev - 1, 1));
+  };
+
+  const handleNextPage = () => {
+    setPage((prev) => Math.min(prev + 1, totalPages));
+  };
+
+  const handleResetFilters = () => {
+    setSearchTerm("");
+    setSeverityFilter("");
+    setStatusFilter("");
+    setPriorityFilter("");
+    setDateFrom("");
+    setDateTo("");
+  };
+
+  const filtersActive =
+    Boolean(searchTerm.trim()) ||
+    Boolean(severityFilter) ||
+    Boolean(statusFilter) ||
+    Boolean(priorityFilter) ||
+    Boolean(dateFrom) ||
+    Boolean(dateTo);
+
+  return (
+    <div className="bg-slate-50 min-h-screen py-8">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between mb-6">
+          <div>
+            <h1 className="text-3xl font-semibold text-gray-800">Damage Reports</h1>
+            <p className="mt-2 text-gray-600 max-w-2xl">
+              Review, triage, and follow up on reported vehicle damage across the fleet.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search by unit, severity, or status"
+              className="w-full sm:w-72 rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Search damage reports"
+            />
+            <Link
+              to="/report-damage"
+              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Report New Damage
+            </Link>
+          </div>
+        </div>
+
+        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          <select
+            value={severityFilter}
+            onChange={(event) => setSeverityFilter(event.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter by severity"
+          >
+            <option value="">All severities</option>
+            {severityLevels.map((level) => (
+              <option key={level} value={level}>
+                {level}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter by damage status"
+          >
+            <option value="">All statuses</option>
+            {statusOptions.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={priorityFilter}
+            onChange={(event) => setPriorityFilter(event.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter by priority"
+          >
+            <option value="">All priorities</option>
+            {priorityLevels.map((priority) => (
+              <option key={priority} value={priority}>
+                {priority}
+              </option>
+            ))}
+          </select>
+
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(event) => setDateFrom(event.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter from date"
+          />
+
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(event) => setDateTo(event.target.value)}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter to date"
+          />
+
+          <button
+            type="button"
+            onClick={handleResetFilters}
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+          >
+            Clear filters
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 border-l-4 border-red-400 bg-red-50 px-4 py-3 text-red-700 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <div className="bg-white shadow rounded-lg">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Unit
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Severity
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Damage Area
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Status
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Priority
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Reported By
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Incident Time
+                  </th>
+                  <th scope="col" className="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {isLoading ? (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-6 text-center text-gray-500">
+                      Loading damage reports...
+                    </td>
+                  </tr>
+                ) : reports.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="px-4 py-6 text-center text-gray-500">
+                      {filtersActive
+                        ? "No damage reports match the current filters. Adjust them and try again."
+                        : "No damage reports found yet."}
+                    </td>
+                  </tr>
+                ) : (
+                  reports.map((report) => (
+                    <tr key={report._id} className="hover:bg-gray-50 transition">
+                      <td className="px-4 py-3 text-sm text-gray-900">
+                        <div className="font-semibold text-gray-800">{report.unitId || 'â€”'}</div>
+                        <div className="text-xs text-gray-500">{report.licensePlate || 'No plate on file'}</div>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700">
+                          {report.severity || 'Unknown'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{report.damageArea || 'â€”'}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{report.damageStatus || 'Reported'}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{report.priority || 'Moderate'}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{report.reportedBy || 'â€”'}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{formatDateTime(report.incidentDateTime)}</td>
+                      <td className="px-4 py-3 text-sm text-right">
+                        <Link
+                          to={`/damage-reports/${report._id}`}
+                          className="text-blue-600 hover:text-blue-800 font-medium"
+                        >
+                          View
+                        </Link>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-gray-600">
+            Showing {reports.length} of {totalReports} matching report(s).
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handlePrevPage}
+              disabled={page <= 1}
+              className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Previous
+            </button>
+            <span className="text-sm text-gray-700">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={page >= totalPages}
+              className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-8 grid gap-3 sm:grid-cols-3">
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 className="text-sm font-semibold text-gray-700">Severity reference</h3>
+            <ul className="mt-2 space-y-1 text-sm text-gray-600">
+              {severityLevels.map((level) => (
+                <li key={level}>{level}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 className="text-sm font-semibold text-gray-700">Status reference</h3>
+            <ul className="mt-2 space-y-1 text-sm text-gray-600">
+              {statusOptions.map((status) => (
+                <li key={status}>{status}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h3 className="text-sm font-semibold text-gray-700">Priority levels</h3>
+            <ul className="mt-2 space-y-1 text-sm text-gray-600">
+              {priorityLevels.map((priority) => (
+                <li key={priority}>{priority}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  useEffect(() => {
+    setPage((prev) => Math.min(prev, totalPages || 1));
+  }, [totalPages]);
+};
+
+export default DamageReportsPage;

--- a/frontend/src/pages/ReportDamagePage.js
+++ b/frontend/src/pages/ReportDamagePage.js
@@ -1,8 +1,764 @@
+import React, { useState } from "react";
+import axios from "axios";
+import {
+  damageAreas,
+  severityLevels,
+  damageCauses,
+  immediateActions,
+  statusOptions,
+  supervisorStatuses,
+  priorityLevels,
+} from "../constants/damageReportOptions";
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:5000";
+const createInitialFormData = () => ({
+  unitId: "",
+  licensePlate: "",
+  incidentDateTime: "",
+  location: "",
+  crew: "",
+  shift: "",
+  damageArea: "",
+  severity: "",
+  damageCause: "",
+  description: "",
+  weather: "",
+  thirdParties: "",
+  policeReportNumber: "",
+  witnesses: "",
+  immediateAction: "",
+  damageStatus: statusOptions[0],
+  repairCost: "",
+  assignedVendor: "",
+  repairDate: "",
+  insuranceClaimFiled: false,
+  insuranceClaimNumber: "",
+  reportedBy: "",
+  supervisorStatus: supervisorStatuses[0],
+  priority: priorityLevels[1],
+  managerNotes: "",
+  notifyTeam: true,
+});
+
 const ReportDamagePage = () => {
+  const [formData, setFormData] = useState(createInitialFormData);
+  const [attachments, setAttachments] = useState([]);
+  const [submitStatus, setSubmitStatus] = useState({ type: "", message: "" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState({});
+
+  const getFieldClasses = (field, extra = "") => {
+    const baseClasses = "mt-1 block w-full rounded-md border px-3 py-2 shadow-sm focus:outline-none focus:ring-2";
+    const stateClasses = errors[field]
+      ? "border-red-500 focus:border-red-500 focus:ring-red-500"
+      : "border-gray-300 focus:border-blue-500 focus:ring-blue-500";
+
+    return [baseClasses, stateClasses, extra].filter(Boolean).join(" ");
+  };
+
+  const messageClassName =
+    submitStatus.type === "success"
+      ? "border-green-400 bg-green-50 text-green-700"
+      : submitStatus.type === "error"
+      ? "border-red-400 bg-red-50 text-red-700"
+      : "border-blue-400 bg-blue-50 text-blue-700";
+
+  const validateForm = () => {
+    const nextErrors = {};
+
+    if (!formData.unitId.trim()) {
+      nextErrors.unitId = "Unit ID is required.";
+    }
+
+    if (!formData.incidentDateTime) {
+      nextErrors.incidentDateTime = "Date and time of the incident is required.";
+    }
+
+    if (!formData.location.trim()) {
+      nextErrors.location = "Location is required.";
+    }
+
+    if (!formData.damageArea) {
+      nextErrors.damageArea = "Select the damaged area.";
+    }
+
+    if (!formData.severity) {
+      nextErrors.severity = "Select the damage severity.";
+    }
+
+    if (!formData.damageCause) {
+      nextErrors.damageCause = "Select the damage cause.";
+    }
+
+    if (!formData.description.trim()) {
+      nextErrors.description = "Add a brief description of the incident.";
+    }
+
+    if (!formData.reportedBy.trim()) {
+      nextErrors.reportedBy = "Reporter name or ID is required.";
+    }
+
+    if (formData.repairCost && Number(formData.repairCost) < 0) {
+      nextErrors.repairCost = "Repair cost cannot be negative.";
+    }
+
+    if (formData.insuranceClaimFiled && !formData.insuranceClaimNumber.trim()) {
+      nextErrors.insuranceClaimNumber = "Add the insurance claim number or uncheck the box.";
+    }
+
+    return nextErrors;
+  };
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+
+    setFormData((prev) => {
+      const nextValue = type === "checkbox" ? checked : value;
+      const updated = { ...prev, [name]: nextValue };
+
+      if (name === "insuranceClaimFiled" && !checked) {
+        updated.insuranceClaimNumber = "";
+      }
+
+      return updated;
+    });
+
+    setErrors((prev) => {
+      const shouldClearClaimNumber = name === "insuranceClaimFiled" && !checked && prev.insuranceClaimNumber;
+
+      if (!prev[name] && !shouldClearClaimNumber) {
+        return prev;
+      }
+
+      const next = { ...prev };
+      delete next[name];
+
+      if (shouldClearClaimNumber) {
+        delete next.insuranceClaimNumber;
+      }
+
+      return next;
+    });
+  };
+
+  const handleFileChange = (event) => {
+    const files = Array.from(event.target.files || []);
+    setAttachments(files);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const formElement = event.currentTarget;
+
+    setIsSubmitting(true);
+    setSubmitStatus({ type: "", message: "" });
+
+    const validationErrors = validateForm();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      setIsSubmitting(false);
+      setSubmitStatus({
+        type: "error",
+        message: "Please fix the highlighted fields before submitting.",
+      });
+      return;
+    }
+
+    setErrors({});
+
+    try {
+      const payload = new FormData();
+
+      Object.entries(formData).forEach(([key, value]) => {
+        if (typeof value === "boolean") {
+          payload.append(key, value ? "true" : "false");
+          return;
+        }
+
+        if (value === undefined || value === null) {
+          return;
+        }
+
+        if (value === "") {
+          return;
+        }
+
+        payload.append(key, value);
+      });
+
+      if (!formData.insuranceClaimFiled) {
+        payload.set("insuranceClaimFiled", "false");
+        payload.delete("insuranceClaimNumber");
+      } else if (formData.insuranceClaimNumber.trim() === "") {
+        payload.delete("insuranceClaimNumber");
+      }
+
+      if (formData.repairCost === "") {
+        payload.delete("repairCost");
+      }
+
+      attachments.forEach((file) => {
+        payload.append("attachments", file);
+      });
+
+      await axios.post(`${API_BASE_URL}/api/damage-reports`, payload, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+
+      setSubmitStatus({
+        type: "success",
+        message: "Damage report submitted successfully.",
+      });
+      setFormData(createInitialFormData());
+      setAttachments([]);
+      formElement.reset();
+    } catch (error) {
+      console.error("Failed to submit damage report:", error);
+      const errorMessage =
+        error.response?.data?.message ||
+        "Something went wrong while saving the report. Please try again.";
+
+      setSubmitStatus({ type: "error", message: errorMessage });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">Report Damage</h1>
-      <p className="mt-2 text-gray-600">This feature is coming soon.</p>
+    <div className="bg-slate-50 min-h-screen py-8">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-semibold text-gray-800">Report Vehicle Damage</h1>
+          <p className="mt-2 text-gray-600">
+            Capture critical details about the incident to support maintenance, insurance, and operational follow-up.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <section className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Unit & Incident Information</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="unitId" className="block text-sm font-medium text-gray-700">
+                  Unit ID / Vehicle Number
+                </label>
+                <input
+                  id="unitId"
+                  name="unitId"
+                  value={formData.unitId}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="UMC-012"
+                  className={getFieldClasses("unitId")}
+                  aria-invalid={Boolean(errors.unitId)}
+                  aria-describedby={errors.unitId ? "unitId-error" : undefined}
+                />
+                {errors.unitId && (
+                  <p id="unitId-error" className="mt-1 text-sm text-red-600">
+                    {errors.unitId}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="licensePlate" className="block text-sm font-medium text-gray-700">
+                  License Plate / VIN
+                </label>
+                <input
+                  id="licensePlate"
+                  name="licensePlate"
+                  value={formData.licensePlate}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="ABC-1234"
+                  className={getFieldClasses("licensePlate")}
+                />
+              </div>
+              <div>
+                <label htmlFor="incidentDateTime" className="block text-sm font-medium text-gray-700">
+                  Date &amp; Time of Incident
+                </label>
+                <input
+                  id="incidentDateTime"
+                  name="incidentDateTime"
+                  value={formData.incidentDateTime}
+                  onChange={handleChange}
+                  type="datetime-local"
+                  className={getFieldClasses("incidentDateTime")}
+                  aria-invalid={Boolean(errors.incidentDateTime)}
+                  aria-describedby={errors.incidentDateTime ? "incidentDateTime-error" : undefined}
+                />
+                {errors.incidentDateTime && (
+                  <p id="incidentDateTime-error" className="mt-1 text-sm text-red-600">
+                    {errors.incidentDateTime}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="location" className="block text-sm font-medium text-gray-700">
+                  Location of Incident
+                </label>
+                <input
+                  id="location"
+                  name="location"
+                  value={formData.location}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="123 Main St, El Paso, TX"
+                  className={getFieldClasses("location")}
+                  aria-invalid={Boolean(errors.location)}
+                  aria-describedby={errors.location ? "location-error" : undefined}
+                />
+                {errors.location && (
+                  <p id="location-error" className="mt-1 text-sm text-red-600">
+                    {errors.location}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="crew" className="block text-sm font-medium text-gray-700">
+                  Crew Assigned
+                </label>
+                <input
+                  id="crew"
+                  name="crew"
+                  value={formData.crew}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="A. Flores, M. Garcia"
+                  className={getFieldClasses("crew")}
+                />
+              </div>
+              <div>
+                <label htmlFor="shift" className="block text-sm font-medium text-gray-700">
+                  Shift
+                </label>
+                <input
+                  id="shift"
+                  name="shift"
+                  value={formData.shift}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="Night Shift"
+                  className={getFieldClasses("shift")}
+                />
+              </div>
+            </div>
+          </section>
+
+          <section className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Damage Details</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="damageArea" className="block text-sm font-medium text-gray-700">
+                  Part / Area Damaged
+                </label>
+                <select
+                  id="damageArea"
+                  name="damageArea"
+                  value={formData.damageArea}
+                  onChange={handleChange}
+                  className={getFieldClasses("damageArea", "bg-white")}
+                  aria-invalid={Boolean(errors.damageArea)}
+                  aria-describedby={errors.damageArea ? "damageArea-error" : undefined}
+                >
+                  <option value="">Select an area</option>
+                  {damageAreas.map((area) => (
+                    <option key={area} value={area}>
+                      {area}
+                    </option>
+                  ))}
+                </select>
+                {errors.damageArea && (
+                  <p id="damageArea-error" className="mt-1 text-sm text-red-600">
+                    {errors.damageArea}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="severity" className="block text-sm font-medium text-gray-700">
+                  Severity of Damage
+                </label>
+                <select
+                  id="severity"
+                  name="severity"
+                  value={formData.severity}
+                  onChange={handleChange}
+                  className={getFieldClasses("severity", "bg-white")}
+                  aria-invalid={Boolean(errors.severity)}
+                  aria-describedby={errors.severity ? "severity-error" : undefined}
+                >
+                  <option value="">Select severity</option>
+                  {severityLevels.map((level) => (
+                    <option key={level} value={level}>
+                      {level}
+                    </option>
+                  ))}
+                </select>
+                {errors.severity && (
+                  <p id="severity-error" className="mt-1 text-sm text-red-600">
+                    {errors.severity}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="damageCause" className="block text-sm font-medium text-gray-700">
+                  Cause of Damage
+                </label>
+                <select
+                  id="damageCause"
+                  name="damageCause"
+                  value={formData.damageCause}
+                  onChange={handleChange}
+                  className={getFieldClasses("damageCause", "bg-white")}
+                  aria-invalid={Boolean(errors.damageCause)}
+                  aria-describedby={errors.damageCause ? "damageCause-error" : undefined}
+                >
+                  <option value="">Select a cause</option>
+                  {damageCauses.map((cause) => (
+                    <option key={cause} value={cause}>
+                      {cause}
+                    </option>
+                  ))}
+                </select>
+                {errors.damageCause && (
+                  <p id="damageCause-error" className="mt-1 text-sm text-red-600">
+                    {errors.damageCause}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="immediateAction" className="block text-sm font-medium text-gray-700">
+                  Immediate Action Taken
+                </label>
+                <select
+                  id="immediateAction"
+                  name="immediateAction"
+                  value={formData.immediateAction}
+                  onChange={handleChange}
+                  className={getFieldClasses("immediateAction", "bg-white")}
+                >
+                  <option value="">Select an action</option>
+                  {immediateActions.map((action) => (
+                    <option key={action} value={action}>
+                      {action}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mt-4">
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+                Detailed Description
+              </label>
+              <textarea
+                id="description"
+                name="description"
+                value={formData.description}
+                onChange={handleChange}
+                rows={4}
+                placeholder="Provide a detailed account of the damage and incident circumstances."
+                className={getFieldClasses("description")}
+                aria-invalid={Boolean(errors.description)}
+                aria-describedby={errors.description ? "description-error" : undefined}
+              />
+              {errors.description && (
+                <p id="description-error" className="mt-1 text-sm text-red-600">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+            <div className="mt-4">
+              <label htmlFor="attachments" className="block text-sm font-medium text-gray-700">
+                Upload Photos / Documents
+              </label>
+              <input
+                id="attachments"
+                name="attachments"
+                onChange={handleFileChange}
+                type="file"
+                multiple
+                className="mt-1 block w-full text-sm text-gray-600 file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-blue-700 hover:file:bg-blue-100"
+              />
+              {attachments.length > 0 && (
+                <p className="mt-2 text-sm text-gray-500">{attachments.length} file(s) selected</p>
+              )}
+            </div>
+          </section>
+
+          <section className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Incident Circumstances</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="weather" className="block text-sm font-medium text-gray-700">
+                  Weather / Road Conditions
+                </label>
+                <input
+                  id="weather"
+                  name="weather"
+                  value={formData.weather}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="Rainy, slick roads"
+                  className={getFieldClasses("weather")}
+                />
+              </div>
+              <div>
+                <label htmlFor="policeReportNumber" className="block text-sm font-medium text-gray-700">
+                  Police / Incident Report Number
+                </label>
+                <input
+                  id="policeReportNumber"
+                  name="policeReportNumber"
+                  value={formData.policeReportNumber}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="TX-45873"
+                  className={getFieldClasses("policeReportNumber")}
+                />
+              </div>
+            </div>
+            <div className="mt-4">
+              <label htmlFor="thirdParties" className="block text-sm font-medium text-gray-700">
+                Third Parties Involved (names, contact info)
+              </label>
+              <textarea
+                id="thirdParties"
+                name="thirdParties"
+                value={formData.thirdParties}
+                onChange={handleChange}
+                rows={3}
+                placeholder="Include other drivers, property owners, or agencies involved."
+                className={getFieldClasses("thirdParties")}
+              />
+            </div>
+            <div className="mt-4">
+              <label htmlFor="witnesses" className="block text-sm font-medium text-gray-700">
+                Witness Information
+              </label>
+              <textarea
+                id="witnesses"
+                name="witnesses"
+                value={formData.witnesses}
+                onChange={handleChange}
+                rows={3}
+                placeholder="Include names, phone numbers, and statements."
+                className={getFieldClasses("witnesses")}
+              />
+            </div>
+          </section>
+
+          <section className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Repair &amp; Follow-Up</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="damageStatus" className="block text-sm font-medium text-gray-700">
+                  Damage Status
+                </label>
+                <select
+                  id="damageStatus"
+                  name="damageStatus"
+                  value={formData.damageStatus}
+                  onChange={handleChange}
+                  className={getFieldClasses("damageStatus", "bg-white")}
+                >
+                  {statusOptions.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="repairCost" className="block text-sm font-medium text-gray-700">
+                  Estimated Repair Cost
+                </label>
+                <input
+                  id="repairCost"
+                  name="repairCost"
+                  value={formData.repairCost}
+                  onChange={handleChange}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="1500"
+                  className={getFieldClasses("repairCost")}
+                  aria-invalid={Boolean(errors.repairCost)}
+                  aria-describedby={errors.repairCost ? "repairCost-error" : undefined}
+                />
+                {errors.repairCost && (
+                  <p id="repairCost-error" className="mt-1 text-sm text-red-600">
+                    {errors.repairCost}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="assignedVendor" className="block text-sm font-medium text-gray-700">
+                  Assigned Mechanic / Vendor
+                </label>
+                <input
+                  id="assignedVendor"
+                  name="assignedVendor"
+                  value={formData.assignedVendor}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="City Fleet Services"
+                  className={getFieldClasses("assignedVendor")}
+                />
+              </div>
+              <div>
+                <label htmlFor="repairDate" className="block text-sm font-medium text-gray-700">
+                  Repair Completion Date
+                </label>
+                <input
+                  id="repairDate"
+                  name="repairDate"
+                  value={formData.repairDate}
+                  onChange={handleChange}
+                  type="date"
+                  className={getFieldClasses("repairDate")}
+                />
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-4">
+              <label className="inline-flex items-center text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  name="insuranceClaimFiled"
+                  checked={formData.insuranceClaimFiled}
+                  onChange={handleChange}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="ml-2">Insurance claim filed?</span>
+              </label>
+              <input
+                id="insuranceClaimNumber"
+                name="insuranceClaimNumber"
+                value={formData.insuranceClaimFiled ? formData.insuranceClaimNumber : ""}
+                onChange={handleChange}
+                type="text"
+                placeholder="Claim #"
+                className={getFieldClasses("insuranceClaimNumber")}
+                disabled={!formData.insuranceClaimFiled}
+                aria-invalid={Boolean(errors.insuranceClaimNumber)}
+                aria-describedby={errors.insuranceClaimNumber ? "insuranceClaimNumber-error" : undefined}
+              />
+            </div>
+            {errors.insuranceClaimNumber && (
+              <p id="insuranceClaimNumber-error" className="mt-1 text-sm text-red-600">
+                {errors.insuranceClaimNumber}
+              </p>
+            )}
+          </section>
+
+          <section className="bg-white shadow rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">Administrative Details</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="reportedBy" className="block text-sm font-medium text-gray-700">
+                  Reported By
+                </label>
+                <input
+                  id="reportedBy"
+                  name="reportedBy"
+                  value={formData.reportedBy}
+                  onChange={handleChange}
+                  type="text"
+                  placeholder="Driver ID or name"
+                  className={getFieldClasses("reportedBy")}
+                  aria-invalid={Boolean(errors.reportedBy)}
+                  aria-describedby={errors.reportedBy ? "reportedBy-error" : undefined}
+                />
+                {errors.reportedBy && (
+                  <p id="reportedBy-error" className="mt-1 text-sm text-red-600">
+                    {errors.reportedBy}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor="supervisorStatus" className="block text-sm font-medium text-gray-700">
+                  Supervisor Review Status
+                </label>
+                <select
+                  id="supervisorStatus"
+                  name="supervisorStatus"
+                  value={formData.supervisorStatus}
+                  onChange={handleChange}
+                  className={getFieldClasses("supervisorStatus", "bg-white")}
+                >
+                  {supervisorStatuses.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="priority" className="block text-sm font-medium text-gray-700">
+                  Priority Level
+                </label>
+                <select
+                  id="priority"
+                  name="priority"
+                  value={formData.priority}
+                  onChange={handleChange}
+                  className={getFieldClasses("priority", "bg-white")}
+                >
+                  {priorityLevels.map((level) => (
+                    <option key={level} value={level}>
+                      {level}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mt-4">
+              <label htmlFor="managerNotes" className="block text-sm font-medium text-gray-700">
+                Fleet Manager Notes
+              </label>
+              <textarea
+                id="managerNotes"
+                name="managerNotes"
+                value={formData.managerNotes}
+                onChange={handleChange}
+                rows={3}
+                placeholder="Internal remarks or follow-up reminders."
+                className={getFieldClasses("managerNotes")}
+              />
+            </div>
+            <div className="mt-4">
+              <label className="inline-flex items-center text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  name="notifyTeam"
+                  checked={formData.notifyTeam}
+                  onChange={handleChange}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                <span className="ml-2">Send notifications to fleet management team</span>
+              </label>
+            </div>
+          </section>
+
+          {submitStatus.message && (
+            <div
+              className={`${messageClassName} border-l-4 rounded-md p-4`}
+              role="alert"
+            >
+              {submitStatus.message}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center rounded-md bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Saving..." : "Submit Damage Report"}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
-created the damage report page
-made several forms for user input
-added a dedicated DamageReport model plus routes for create/list/show/update with unit sync, filtering, and multipart upload support
-expose /uploads on the API, store evidence under uploads/damage_reports, and ignore the directory in git
-refactor the report form to submit FormData, centralise option constants, and surface a damage report index + detail page with -filtering, pagination, and attachment links
-update nav/routes so the new UI is reachable from the app